### PR TITLE
typo & add type: auto for provisioning

### DIFF
--- a/doc/1/guides/provisioning/index.md
+++ b/doc/1/guides/provisioning/index.md
@@ -24,7 +24,7 @@ The document ID is `plugin--device-manager`.
 {
   "type": "device-manager",
   "device-manager": {
-    "autoProvisionning": true
+    "provisioningStrategy": 'auto' | 'catalog'
   }
 }
 ```

--- a/features/Provisionning.feature
+++ b/features/Provisionning.feature
@@ -4,7 +4,7 @@ Feature: Device Provisionning
   Scenario: Provision device in the catalog
     Given a collection "device-manager":"config"
     And I "update" the document "plugin--device-manager" with content:
-      | device-manager.autoProvisionning | false |
+      | device-manager.provisioningStrategy | "catalog" |
     And I "create" the document "catalog--DummyTemp-12345" with content:
       | type               | "catalog"         |
       | catalog.deviceId   | "DummyTemp-12345" |

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -139,7 +139,7 @@ After({ tags: '@realtime' }, function () {
 After({ tags: '@provisioning', timeout: 60 * 1000 }, async function () {
   await this.sdk.document.update('device-manager', 'config', 'plugin--device-manager', {
     'device-manager': {
-      autoProvisionning: true,
+      provisioningStrategy: 'auto',
     }
   });
 });

--- a/lib/DeviceManagerPlugin.ts
+++ b/lib/DeviceManagerPlugin.ts
@@ -154,7 +154,7 @@ export class DeviceManagerPlugin extends Plugin {
 
             'device-manager': {
               properties: {
-                autoProvisionning: { type: 'boolean' },
+                provisioningStrategy: { type: 'keyword' },
               }
             }
           }
@@ -344,7 +344,7 @@ export class DeviceManagerPlugin extends Plugin {
         this.config.configCollection,
         {
           type: 'device-manager',
-          'device-manager': { autoProvisionning: true }
+          'device-manager': { provisioningStrategy: 'auto' }
         },
         'plugin--device-manager');
     }

--- a/lib/core-classes/PayloadService.ts
+++ b/lib/core-classes/PayloadService.ts
@@ -117,7 +117,7 @@ export class PayloadService {
   /**
    * Device provisioning strategy.
    *
-   * If autoProvisionning is on, device is automatically registered, otherwise
+   * If provisioningStrategy is on auto, device is automatically registered, otherwise
    * we request the admin provisioning catalog to ensure this device is allowed
    * to register.
    *
@@ -139,15 +139,16 @@ export class PayloadService {
       this.config.configCollection,
       'plugin--device-manager');
 
-    const autoProvisionning: boolean = pluginConfigDocument._source['device-manager'].autoProvisionning;
+    console.log('pluginConfigDocument', pluginConfigDocument);
+    const autoProvisioningStrategy: boolean = pluginConfigDocument._source['device-manager'].provisioningStrategy === 'auto';
 
     const catalogEntry = await this.getCatalogEntry(this.config.adminIndex, device._id);
 
-    if (! autoProvisionning && ! catalogEntry) {
+    if (! autoProvisioningStrategy && ! catalogEntry) {
       throw new BadRequestError(`Device ${device._id} is not provisionned.`);
     }
 
-    if (! autoProvisionning && catalogEntry.content.authorized === false) {
+    if (! autoProvisioningStrategy && catalogEntry.content.authorized === false) {
       throw new BadRequestError(`Device ${device._id} is not allowed for registration.`);
     }
 

--- a/lib/core-classes/PayloadService.ts
+++ b/lib/core-classes/PayloadService.ts
@@ -117,7 +117,7 @@ export class PayloadService {
   /**
    * Device provisioning strategy.
    *
-   * If provisioningStrategy is on auto, device is automatically registered, otherwise
+   * If provisioningStrategy is "auto," device is automatically registered, otherwise
    * we request the admin provisioning catalog to ensure this device is allowed
    * to register.
    *

--- a/lib/core-classes/PayloadService.ts
+++ b/lib/core-classes/PayloadService.ts
@@ -139,7 +139,6 @@ export class PayloadService {
       this.config.configCollection,
       'plugin--device-manager');
 
-    console.log('pluginConfigDocument', pluginConfigDocument);
     const autoProvisioningStrategy: boolean = pluginConfigDocument._source['device-manager'].provisioningStrategy === 'auto';
 
     const catalogEntry = await this.getCatalogEntry(this.config.adminIndex, device._id);


### PR DESCRIPTION
# Description

This PR change the `autoProvisioning` property and standardize it with the existing catalog one.

