### PR TITLE
Allow the developper to import devices using csv a compatible syntax

### DIFF
--- a/doc/1/controllers/device/import-devices/index.md
+++ b/doc/1/controllers/device/import-devices/index.md
@@ -2,7 +2,7 @@
 code: true
 type: page
 title: importDevices
-description: Link a device to an asset
+description: Import devices from a csv file
 ---
 
 # importDevices
@@ -27,7 +27,7 @@ Method: POST
   "controller": "device-manager/device",
   "action": "importDevices",
   "body": {
-    "csv": "qos.battery,measures.temperature.degree\\n80,23.3"
+    "csv": "_id,reference,model\\nDummyTemp-imported,detached,DummyTemp_imported"
   }
 }
 ```
@@ -35,7 +35,7 @@ Method: POST
 ### Kourou
 
 ```bash
-kourou device-manager/device:importDevices --body '{ "csv": "qos.battery,measures.temperature.degree\\n80,23.3" }'
+kourou device-manager/device:importDevices --body '{ "csv": "_id,reference,model\\nDummyTemp-imported,detached,DummyTemp_imported" }'
 ```
 ---
 

--- a/doc/1/controllers/device/import-devices/index.md
+++ b/doc/1/controllers/device/import-devices/index.md
@@ -1,0 +1,64 @@
+---
+code: true
+type: page
+title: importDevices
+description: Link a device to an asset
+---
+
+# importDevices
+
+Import devices from a CSV file
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/devices/_import[?refresh=wait_for]
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/device",
+  "action": "importDevices",
+  "body": {
+    "csv": "qos.battery,measures.temperature.degree\\n80,23.3"
+  }
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/device:importDevices --body '{ "csv": "qos.battery,measures.temperature.degree\\n80,23.3" }'
+```
+---
+
+## Body properties
+
+- `csv`: a csv syntax compatible containing at least this two headers `tenantId,deviceId` with their corresponding values
+
+### Optional:
+
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the documents are indexed
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "index": "<index>",
+  "controller": "device-manager/device",
+  "action": "importDevices",
+  "requestId": "<unique request identifier>",
+  "result": {}
+}
+```

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -131,13 +131,13 @@ Feature: Device Manager device controller
       | measures.temperature.degree             | 23.3                               |
       | measures.temperature.origin.qos.battery | 80                                 |
 
-    Scenario: Link the same device to another asset should fail
+  Scenario: Link the same device to another asset should fail
     When I successfully execute the action "device-manager/device":"linkAsset" with args:
       | _id     | "DummyTemp-attached_ayse_unlinked" |
       | assetId | "PERFO-unlinked"                   |
     And I execute the action "device-manager/device":"linkAsset" with args:
       | _id     | "DummyTemp-attached_ayse_unlinked" |
-      | assetId | "TIKO-unlinked"                   |
+      | assetId | "TIKO-unlinked"                    |
     Then I should receive an error matching:
       | message | "Device \"DummyTemp-attached_ayse_unlinked\" is already linked to the asset \"PERFO-unlinked\" you need to detach it first." |
 
@@ -352,3 +352,12 @@ Feature: Device Manager device controller
       | collection | "payloads"       |
     Then I should receive a result matching:
       | total | 1 |
+
+  Scenario: Import devices using csv
+    Given I successfully execute the action "device-manager/device":"importDevices" with args:
+      | body.csv | "qos.battery,measures.temperature.degree,tenantId,assetID\\n80,23.3, null, null" |
+    Then The document "device-manager":"devices":"DummyTemp-attached_ayse_unlinked" content match:
+      | qos.battery                 | 80   |
+      | measures.temperature.degree | 23.3 |
+      | tenatId                     | null |
+      | assetID                     | null |

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -355,9 +355,7 @@ Feature: Device Manager device controller
 
   Scenario: Import devices using csv
     Given I successfully execute the action "device-manager/device":"importDevices" with args:
-      | body.csv | "qos.battery,measures.temperature.degree,tenantId,assetID\\n80,23.3, null, null" |
+      | body.csv | "qos.battery,measures.temperature.degree\\n80,23.3" |
     Then The document "device-manager":"devices":"DummyTemp-attached_ayse_unlinked" content match:
       | qos.battery                 | 80   |
       | measures.temperature.degree | 23.3 |
-      | tenatId                     | null |
-      | assetID                     | null |

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -355,7 +355,10 @@ Feature: Device Manager device controller
 
   Scenario: Import devices using csv
     Given I successfully execute the action "device-manager/device":"importDevices" with args:
-      | body.csv | "qos.battery,measures.temperature.degree\\n80,23.3" |
-    Then The document "device-manager":"devices":"DummyTemp-attached_ayse_unlinked" content match:
-      | qos.battery                 | 80   |
-      | measures.temperature.degree | 23.3 |
+      | body.csv | "_id,reference,model\\nDummyTemp-imported,detached,DummyTemp_imported" |
+    Then I successfully execute the action "collection":"refresh" with args:
+      | index      | "device-manager" |
+      | collection | "devices"        |
+    Then The document "device-manager":"devices":"DummyTemp-imported" content match:
+      | reference | "detached"           |
+      | model     | "DummyTemp_imported" |

--- a/lib/controllers/DeviceController.ts
+++ b/lib/controllers/DeviceController.ts
@@ -253,21 +253,17 @@ export class DeviceController extends CRUDController {
   }
 
   async importDevices (request: KuzzleRequest) {
-    const body = request.getBody();
+    const content = request.getBodyString('csv');
 
-    if (body.csv) {
-      const devices = await csv({ delimiter: 'auto' })
-        .fromString(body.csv);
+    const devices = await csv({ delimiter: 'auto' })
+      .fromString(content);
 
-      this.deviceService.importDevices(
-        devices,
-        {
-          strict: true,
-          options: { ...request.input.args }
-        });
-    } else {
-      throw new BadRequestError('Body does not have a csv property')
-    }
+    this.deviceService.importDevices(
+      devices,
+      {
+        strict: true,
+        options: { ...request.input.args }
+      });
   }
 
 

--- a/lib/controllers/DeviceController.ts
+++ b/lib/controllers/DeviceController.ts
@@ -72,6 +72,10 @@ export class DeviceController extends CRUDController {
         prunePayloads: {
           handler: this.prunePayloads.bind(this),
           http: [{ verb: 'delete', path: 'device-manager/devices/_prunePayloads' }]
+        },
+        importDevices: {
+          handler: this.importDevices.bind(this),
+          http: [{ verb: 'post', path: 'device-manager/devices/_import' }]
         }
       }
     };
@@ -246,6 +250,24 @@ export class DeviceController extends CRUDController {
       this.config.adminIndex,
       'payloads',
       { query: { bool: { filter } } });
+  }
+
+  async importDevices (request: KuzzleRequest) {
+    const body = request.getBody();
+
+    if (body.csv) {
+      const devices = await csv({ delimiter: 'auto' })
+        .fromString(body.csv);
+
+      this.deviceService.importDevices(
+        devices,
+        {
+          strict: true,
+          options: { ...request.input.args }
+        });
+    } else {
+      throw new BadRequestError('Body does not have a csv property')
+    }
   }
 
 

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -375,19 +375,15 @@ export class DeviceService {
     return results;
   }
 
-  async importDevices(devices: any,
+  async importDevices(devices: JSONObject,
     { strict, options }: { strict?: boolean, options?: JSONObject }) {
       const results = {
         errors: [],
         successes: [],
       };
 
-    console.log(devices)
-
     const deviceDocuments = devices
-      .map(device => ({ _id: device._id || uuidv4(), body: device }))
-
-    console.log(deviceDocuments);
+      .map((device: JSONObject) => ({ _id: device._id || uuidv4(), body: device }))
 
     const createdDevices = await this.writeToDatabase(
       deviceDocuments,
@@ -398,8 +394,6 @@ export class DeviceService {
           'devices',
           result,
           { strict, ...options });
-
-        console.log(JSON.stringify(created));
 
         return {
           success: results.successes.concat(created.successes, createdDevices.successes),

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -385,7 +385,7 @@ export class DeviceService {
     const deviceDocuments = devices
       .map((device: JSONObject) => ({ _id: device._id || uuidv4(), body: device }))
 
-    const createdDevices = await this.writeToDatabase(
+    await this.writeToDatabase(
       deviceDocuments,
       async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
         
@@ -396,8 +396,8 @@ export class DeviceService {
           { strict, ...options });
 
         return {
-          success: results.successes.concat(created.successes, createdDevices.successes),
-          errors: results.errors.concat(created.errors, createdDevices.errors)
+          success: results.successes.concat(created.successes),
+          errors: results.errors.concat(created.errors)
         }
       });
 

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -10,6 +10,7 @@ import {
 } from 'kuzzle';
 
 import { v4 as uuidv4 } from 'uuid';
+import omit from 'lodash/omit';
 
 import { Decoder } from './Decoder';
 import { Device } from '../models';
@@ -375,7 +376,8 @@ export class DeviceService {
     return results;
   }
 
-  async importDevices(devices: JSONObject,
+  async importDevices(
+    devices: JSONObject,
     { strict, options }: { strict?: boolean, options?: JSONObject }) {
       const results = {
         errors: [],
@@ -383,7 +385,7 @@ export class DeviceService {
       };
 
     const deviceDocuments = devices
-      .map((device: JSONObject) => ({ _id: device._id || uuidv4(), body: device }))
+      .map((device: JSONObject) => ({ _id: device._id || uuidv4(), body: omit(device, ['_id']) }))
 
     await this.writeToDatabase(
       deviceDocuments,
@@ -396,8 +398,8 @@ export class DeviceService {
           { strict, ...options });
 
         return {
-          success: results.successes.concat(created.successes),
-          errors: results.errors.concat(created.errors)
+          success: results.successes.push(...created.successes),
+          errors: results.errors.push(...created.errors)
         }
       });
 

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -10,7 +10,6 @@ import {
 } from 'kuzzle';
 
 import { v4 as uuidv4 } from 'uuid';
-import omit from 'lodash/omit'
 
 import { Decoder } from './Decoder';
 import { Device } from '../models';

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -9,6 +9,9 @@ import {
   Document
 } from 'kuzzle';
 
+import { v4 as uuidv4 } from 'uuid';
+import omit from 'lodash/omit'
+
 import { Decoder } from './Decoder';
 import { Device } from '../models';
 import { DeviceManagerConfig } from '../DeviceManagerPlugin';
@@ -86,17 +89,17 @@ export class DeviceService {
 
       const { errors, successes } = await this.writeToDatabase(
         deviceDocuments,
-        async (deviceDocuments: DeviceMRequestContent[]): Promise<JSONObject> => {
+        async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
           const updated = await this.sdk.document.mUpdate(
             this.config.adminIndex,
             'devices',
-            deviceDocuments,
+            result,
             { strict, ...options });
 
           await this.sdk.document.mCreate(
             document.tenantId,
             'devices',
-            deviceDocuments,
+            result,
             { strict, ...options });
 
             return {
@@ -156,18 +159,18 @@ export class DeviceService {
 
       const { errors, successes } = await this.writeToDatabase(
         deviceDocuments,
-        async (deviceDocuments: DeviceMRequestContent[]): Promise<JSONObject> => {
+        async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
 
         const updated = await this.sdk.document.mUpdate(
           this.config.adminIndex,
           'devices',
-          deviceDocuments,
+          result,
           { strict, ...options });
 
           await this.sdk.document.mDelete(
             document.tenantId,
             'devices',
-            deviceDocuments.map(device => device._id),
+            result.map(device => device._id),
             { strict, ...options });
 
           return {
@@ -247,17 +250,17 @@ export class DeviceService {
 
       const updatedDevice = await this.writeToDatabase(
         deviceDocuments,
-        async (deviceDocuments: DeviceMRequestContent[]): Promise<JSONObject> => {
+        async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
           const updated = await this.sdk.document.mUpdate(
             this.config.adminIndex,
             'devices',
-            deviceDocuments,
+            result,
             { strict, ...options });
 
           await this.sdk.document.mUpdate(
             document.tenantId,
             'devices',
-            deviceDocuments,
+            result,
             { strict, ...options });
 
           return {
@@ -268,11 +271,11 @@ export class DeviceService {
 
       const updatedAssets = await this.writeToDatabase(
         assetDocuments,
-        async (assetDocuments: DeviceMRequestContent[]): Promise<JSONObject> => {
+        async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
           const updated = await this.sdk.document.mUpdate(
             document.tenantId,
             'assets',
-            assetDocuments,
+            result,
             { strict, ...options });
 
           return {
@@ -330,17 +333,17 @@ export class DeviceService {
 
       const updatedDevice = await this.writeToDatabase(
         deviceDocuments,
-        async (deviceDocuments: DeviceMRequestContent[]): Promise<JSONObject> => {
+        async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
           const updated = await this.sdk.document.mUpdate(
             this.config.adminIndex,
             'devices',
-            deviceDocuments,
+            result,
             { strict, ...options });
 
           await this.sdk.document.mUpdate(
             document.tenantId,
             'devices',
-            deviceDocuments,
+            result,
             { strict, ...options });
 
           return {
@@ -351,12 +354,12 @@ export class DeviceService {
 
       const updatedAssets = await this.writeToDatabase(
         assetDocuments,
-        async (assetDocuments: DeviceMRequestContent[]): Promise<JSONObject> => {
+        async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
 
           const updated = await this.sdk.document.mUpdate(
             document.tenantId,
             'assets',
-            assetDocuments,
+            result,
             { strict, ...options });
 
           return {
@@ -369,6 +372,41 @@ export class DeviceService {
       results.successes.concat(updatedDevice.successes, updatedAssets.successes);
       results.errors.concat(updatedDevice.errors, updatedDevice.errors);
     }
+
+    return results;
+  }
+
+  async importDevices(devices: any,
+    { strict, options }: { strict?: boolean, options?: JSONObject }) {
+      const results = {
+        errors: [],
+        successes: [],
+      };
+
+    console.log(devices)
+
+    const deviceDocuments = devices
+      .map(device => ({ _id: device._id || uuidv4(), body: device }))
+
+    console.log(deviceDocuments);
+
+    const createdDevices = await this.writeToDatabase(
+      deviceDocuments,
+      async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
+        
+        const created = await this.sdk.document.mCreate(
+          'device-manager',
+          'devices',
+          result,
+          { strict, ...options });
+
+        console.log(JSON.stringify(created));
+
+        return {
+          success: results.successes.concat(created.successes, createdDevices.successes),
+          errors: results.errors.concat(created.errors, createdDevices.errors)
+        }
+      });
 
     return results;
   }


### PR DESCRIPTION
# Description

This PR allow the developer to import device within the app using the CSV format

## importDevices

Import devices from a CSV file

---

## Query Syntax

### HTTP

```http
URL: http://kuzzle:7512/_/device-manager/devices/_import[?refresh=wait_for]
Method: POST
```

### Other protocols

```js
{
  "controller": "device-manager/device",
  "action": "importDevices",
  "body": {
    "csv": "qos.battery,measures.temperature.degree\\n80,23.3"
  }
}
```

### Kourou

```bash
kourou device-manager/device:importDevices --body '{ "csv": "qos.battery,measures.temperature.degree\\n80,23.3" }'
```
---

## Body properties

- `csv`: a csv syntax compatible containing at least this two headers `tenantId,deviceId` with their corresponding values

### Optional:

- `refresh`: if set to `wait_for`, Kuzzle will not respond until the documents are indexed

---

## Response

```js
{
  "status": 200,
  "error": null,
  "index": "<index>",
  "controller": "device-manager/device",
  "action": "importDevices",
  "requestId": "<unique request identifier>",
  "result": {}
}
```


closes #132 